### PR TITLE
invalid route to dapp.com updated

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -1122,7 +1122,7 @@ export const routes = [
         },
         {
           url:
-            "https://www.dapp.com/search/tron",
+            "https://www.dapp.com/search_product/?keyword=tron",
           icon: false,
           label: "DAPP.COM"
         },


### PR DESCRIPTION
the previous route to dapp.com search no longer valid, probably because of changes on their site